### PR TITLE
fetch: new css and small changes

### DIFF
--- a/board.html
+++ b/board.html
@@ -9,10 +9,13 @@
   <link rel="stylesheet" href="./css/standard.css"/>
   <link rel="stylesheet" href="./css/color.css"/>
   <link rel="stylesheet" href="./css/style.css"/>
-  <link rel="stylesheet" href="./css/responsive.css"/>
   <link rel="stylesheet" href="./css/board.css"/>
   <link rel="stylesheet" href="./css/board_second.css"/>
-
+  <link rel="stylesheet" href="./css/add_task.css">
+  <link rel="stylesheet" href="./css/responsive.css"/>
+  <link rel="stylesheet" href="./css/responsive2_for_board.css/kb-desktop.css">
+  <link rel="stylesheet" href="./css/responsive2_for_board.css/kb-mobile.css">
+  
   <title>Join</title>
 </head>
 <body>

--- a/css/board_add_task_modal.css
+++ b/css/board_add_task_modal.css
@@ -1,0 +1,161 @@
+#at-modal .at-dialog {
+  width: min(1040px, 96vw);
+  height: calc(100vh - 64px);
+  border-radius: 24px;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+  padding: 32px 32px 24px;
+}
+
+#at-modal .at-header h2 {
+  font: 800 48px/1.1 Inter;
+  margin: 0 0 16px;
+}
+
+#at-modal .at-grid {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px 40px;
+  align-items: start;
+}
+
+#at-modal .at-grid::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  background: #E5E7EB;
+  transform: translateX(-0.5px);
+}
+
+#at-modal .at-col,
+#at-modal .at-col--right {
+  display: grid;
+  gap: 16px;
+}
+
+#at-modal .field {
+  display: grid;
+  gap: 6px;
+}
+
+#at-modal .field__label {
+  font: 600 16px/1.3 Inter, system-ui;
+  color: #1F2937;
+}
+
+#at-modal .req {
+  color: #EF4444;
+  margin-left: 2px;
+}
+
+#at-modal .input,
+#at-modal .textarea,
+#at-modal .select {
+  width: 100%;
+  border: 1px solid #D1D5DB;
+  background: #fff;
+  border-radius: 10px;
+  padding: 12px 14px;
+  font: 500 16px/1.35 Inter, system-ui;
+  outline: none;
+}
+
+#at-modal .input:focus,
+#at-modal .textarea:focus,
+#at-modal .select:focus {
+  border-color: #94A3B8;
+  box-shadow: 0 0 0 3px rgba(41,171,226,.15);
+}
+
+#at-modal .textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+#at-modal .priority {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 12px;
+}
+
+#at-modal .priority__btn {
+  padding: 10px 16px;
+  border: 1px solid #E5E7EB;
+  border-radius: 12px;
+  background: #FFFFFF;
+  font: 700 15px/1 Inter, system-ui;
+  color: #111827;
+  cursor: pointer;
+  transition: background .12s, border-color .12s, transform .06s;
+}
+
+#at-modal .priority__btn:active {
+  transform: scale(.98);
+}
+
+#at-modal .priority__btn--active {
+  background: #FFB001;
+  border-color: #FFB001;
+  color: #111827;
+}
+
+#at-modal .subtasks {
+  display: grid;
+  gap: 10px;
+}
+
+#at-modal .subtasks__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+#at-modal .subtasks__list li {
+  padding: 10px 12px;
+  border: 1px solid #E5E7EB;
+  border-radius: 10px;
+  background: #fff;
+}
+
+#at-modal .at-footer {
+  margin-top: 28px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+#at-modal .btn {
+  padding: 12px 18px;
+  border-radius: 12px;
+  border: 1px solid #E5E7EB;
+  background: #F3F4F6;
+  font: 700 15px/1 Inter, system-ui;
+  color: #111827;
+  cursor: pointer;
+}
+
+#at-modal .btn-primary {
+  background: #2A3647;
+  border-color: #2A3647;
+  color: #FFFFFF;
+}
+
+#at-modal .btn:hover {
+  filter: brightness(.98);
+}
+
+@media (max-width: 1023px) {
+  #at-modal .at-grid {
+    grid-template-columns: 1fr;
+  }
+  #at-modal .at-grid::after {
+    display: none;
+  }
+}

--- a/css/board_second.css
+++ b/css/board_second.css
@@ -94,7 +94,6 @@
   padding:6px 12px;
   border-radius:10px;
   color:#fff;
-  font-weight:700;
   font-size:22px;
 }
 
@@ -377,42 +376,29 @@
 
 .kb-prio--high .kb-prio__text{color:#DC2626;}
 
+.kb-prio {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 22px;
+}
+
+.kb-prio__icon {
+  width: 22px;
+  height: 22px;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
 .kb-prio--low .kb-prio__icon {
   background-image: url("../assets/img/green_low_urgent.svg");
 }
 
 .kb-prio--medium .kb-prio__icon {
-  background-image: url("../assets/img/Prio%20media.svg"); 
+  background-image: url("../assets/img/Prio%20media.svg");
 }
 
 .kb-prio--high .kb-prio__icon {
   background-image: url("../assets/img/red_high_urgent.svg");
-}
-
-
-.kb-prio{
-  display:flex;
-  align-items:center;
-  justify-content:flex-end;
-  min-width:22px;
-}
-
-.kb-prio__icon{
-  width:22px;
-  height:22px;
-  background-size:contain;
-  background-position:center;
-  background-repeat:no-repeat;
-}
-
-.kb-prio--low .kb-prio__icon{
-  background-image:url("./assets/img/green_low_urgent.svg");
-}
-
-.kb-prio--medium .kb-prio__icon{
-  background-image:url("./assets/img/Prio media.svg");
-}
-
-.kb-prio--high .kb-prio__icon{
-  background-image:url("./assets/img/red_high_urgent.svg");
 }

--- a/css/responsive_for_board.css/kb-desktop.css
+++ b/css/responsive_for_board.css/kb-desktop.css
@@ -1,0 +1,123 @@
+/* ===== Desktop polish (>=1024px) ===== */
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .kb-columns {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 22px;
+  }
+}
+@media (min-width: 1400px) {
+  .kb-columns {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 24px;
+  }
+  .kb {
+    padding: 28px 40px 40px;
+  }
+}
+@media (min-width: 1024px) {
+  .kb-toolbar {
+    grid-template-columns: 1fr auto auto;
+    align-items: end;
+    gap: 14px;
+  }
+  .kb-title {
+    font-size: 48px;
+    line-height: 1.1;
+    margin: 0 0 2px 0;
+  }
+  .kb-search {
+    width: 360px;
+  }
+  .kb-search input {
+    height: 46px;
+  }
+  .kb-add-btn {
+    height: 46px;
+    padding: 0 16px;
+  }
+  .kb-col-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+  .kb-col-title {
+    margin: 0;
+    flex: 1;
+    font-size: 19px;
+  }
+  .kb-col-add {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    border: 2px solid #2A3647;
+    background: #FFFFFF;
+    display: inline-grid;
+    place-items: center;
+    line-height: 1;
+    box-shadow: none;
+  }
+  .kb-col-add::after {
+    content: "+";
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2A3647;
+    transform: translateY(-1px);
+  }
+  .kb-col-add:hover {
+    border-color: #29ABE2;
+    background: #FFFFFF;
+  }
+  .kb-empty {
+    height: 64px;
+    border-radius: 12px;
+  }
+  .kb-card {
+    margin-top: 16px;
+    padding: 16px 16px 14px;
+  }
+  .kb-card-title {
+    font-size: 18px;
+  }
+  .kb-card-desc {
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 1024px) {
+  .sidebar {
+    display: none;
+  }
+  .headercontainer {
+    margin-left: 0;
+  }
+  .kb {
+    padding: 24px 24px 40px;
+    min-height: calc(100vh - 72px);
+  }
+  .kb-toolbar {
+    grid-template-columns: 1fr auto;
+    gap: 12px;
+  }
+  .kb-title {
+    font-size: 40px;
+  }
+  .kb-actions {
+    gap: 12px;
+  }
+  .kb-search {
+    width: 100%;
+    max-width: 420px;
+  }
+  .kb-search input {
+    height: 44px;
+  }
+  .kb-add-btn {
+    height: 44px;
+  }
+  .kb-columns {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+}

--- a/css/responsive_for_board.css/kb-mobile.css
+++ b/css/responsive_for_board.css/kb-mobile.css
@@ -1,0 +1,394 @@
+@media (max-width: 768px) {
+  .kb {
+    padding: 20px 20px 92px;
+  }
+  .kb-toolbar {
+    grid-template-columns: 1fr;
+  }
+  .kb-title {
+    font-size: 34px;
+  }
+  .kb-columns {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 18px;
+  }
+  .kb-card {
+    gap: 6px;
+  }
+  .kb-card-title {
+    font-size: 17px;
+  }
+  .kb-card-desc {
+    font-size: 13px;
+  }
+  .kb-chip {
+    font-size: 13px;
+    height: 28px;
+    width: auto;
+    padding: 5px 10px;
+  }
+}
+
+@media (max-width: 480px) {
+  .kb {
+    padding: 16px 16px 96px;
+  }
+  .kb-title {
+    font-size: 30px;
+  }
+  .kb-toolbar {
+    position: relative;
+    gap: 10px;
+  }
+  .kb-add-btn {
+    position: absolute;
+    top: 6px;
+    right: 0;
+    height: 44px;
+    min-width: 44px;
+    padding: 0;
+    border-radius: 12px;
+    display: inline-grid;
+    place-items: center;
+    font-size: 0;
+    background: #2A3647;
+  }
+  .kb-add-btn:hover {
+    background: #29ABE2;
+  }
+  .kb-add-btn .kb-plus {
+    font-size: 20px;
+    margin: 0;
+    line-height: 1;
+    color: #FFFFFF;
+  }
+  .kb-actions {
+    display: block;
+    width: 100%;
+    grid-auto-flow: row;
+    justify-items: stretch;
+    margin-top: 8px;
+    padding-right: 56px;
+  }
+  .kb-search {
+    max-width: none;
+    width: 100%;
+  }
+  .kb-search input {
+    height: 44px;
+    font-size: 15px;
+    padding: 0 42px 0 14px;
+  }
+  .kb-columns {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+  .kb-col {
+    min-width: 0;
+  }
+  .kb-col-head {
+    margin-bottom: 8px;
+    align-items: center;
+  }
+  .kb-col-title {
+    font-size: 18px;
+    margin: 0;
+  }
+  .kb-col-add {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    border: 2px solid #2A3647;
+    background: #FFFFFF;
+    display: inline-grid;
+    place-items: center;
+    line-height: 1;
+    box-shadow: none;
+  }
+  .kb-col-add::after {
+    content: "+";
+    font-weight: 700;
+    font-size: 18px;
+    color: #2A3647;
+    transform: translateY(-1px);
+  }
+  .kb-col-add:hover {
+    border-color: #29ABE2;
+    background: #FFFFFF;
+  }
+  .kb-empty {
+    height: 56px;
+    font-size: 13px;
+  }
+  .kb-card {
+    padding: 14px;
+    border-radius: 16px;
+    margin-top: 12px;
+  }
+  .kb-card-title {
+    font-size: 16px;
+  }
+  .kb-card-desc {
+    font-size: 13px;
+  }
+  .kb-progress-row {
+    gap: 10px;
+  }
+  .kb-subtasks {
+    font-size: 11px;
+  }
+  .kb-avatar {
+    width: 28px;
+    height: 28px;
+    font-size: 11px;
+  }
+  .kb-prio {
+    min-width: 20px;
+  }
+  .kb-prio__icon {
+    width: 20px;
+    height: 20px;
+  }
+  .kb {
+    overflow-x: hidden;
+  }
+  .kb-columns {
+    overflow-x: hidden;
+  }
+  .kb-col {
+    overflow-x: hidden;
+  }
+  .kb-card {
+    overflow-x: hidden;
+  }
+}
+
+@media (max-width: 360px) {
+  .kb {
+    padding: 14px 12px 96px;
+  }
+  .kb-title {
+    font-size: 26px;
+  }
+  .kb-col-title {
+    font-size: 17px;
+  }
+  .kb-card {
+    padding: 12px;
+    border-radius: 14px;
+  }
+  .kb-card-title {
+    font-size: 15px;
+  }
+  .kb-card-desc {
+    font-size: 12px;
+  }
+  .kb-chip {
+    font-size: 12px;
+    padding: 4px 8px;
+    height: 24px;
+  }
+}
+
+@media (max-width: 320px) {
+  .kb {
+    padding: 12px 10px 96px;
+  }
+  .kb-title {
+    font-size: 24px;
+  }
+  .kb-actions {
+    margin-top: 10px;
+    padding-right: 52px;
+  }
+  .kb-search input {
+    height: 42px;
+    font-size: 14px;
+    padding: 0 38px 0 12px;
+  }
+  .kb-add-btn {
+    height: 42px;
+    min-width: 42px;
+    top: 4px;
+  }
+  .kb-add-btn .kb-plus {
+    font-size: 18px;
+  }
+  .kb-col-title {
+    font-size: 16px;
+  }
+  .kb-empty {
+    height: 52px;
+    font-size: 12px;
+  }
+  .kb-card {
+    gap: 6px;
+    padding: 12px;
+    border-radius: 12px;
+  }
+  .kb-card-title {
+    font-size: 14.5px;
+  }
+  .kb-card-desc {
+    font-size: 12px;
+  }
+  .kb-progress-row {
+    gap: 8px;
+  }
+  .kb-subtasks {
+    font-size: 10.5px;
+  }
+  .kb-avatar {
+    width: 26px;
+    height: 26px;
+    font-size: 10px;
+  }
+  .kb-prio__icon {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+@media (max-width: 768px) {
+  #at-modal .at-dialog {
+    width: 100vw;
+    height: 100vh;
+    max-height: 100vh;
+    border-radius: 16px;
+    padding: 20px 16px 16px;
+  }
+  #at-modal .at-header h2 {
+    font: 800 28px / 1.15 Inter;
+    margin-bottom: 10px;
+  }
+  #at-modal .at-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+  #at-modal .at-grid::after {
+    display: none;
+  }
+  #at-modal .btn {
+    padding: 10px 14px;
+    border-radius: 10px;
+  }
+}
+
+@media (max-width: 600px) {
+  .td-dialog {
+    width: 100vw;
+    height: calc(100vh - 20px);
+    border-radius: 16px;
+    padding: 18px 14px 12px;
+  }
+  .td-title {
+    font-size: 28px;
+    margin: 18px 0 8px;
+  }
+  .td-desc {
+    font-size: 14px;
+  }
+  .td-chip {
+    font-size: 14px;
+    padding: 5px 10px;
+    border-radius: 8px;
+  }
+  .td-meta .td-row {
+    gap: 8px;
+    margin-top: 16px;
+  }
+  .td-label {
+    min-width: 84px;
+    font-size: 14px;
+  }
+  .td-value {
+    font-size: 14px;
+  }
+  #td-subtasks {
+    margin-top: 12px;
+  }
+  #td-subtasks-list {
+    gap: 10px;
+  }
+  .td-task__label {
+    font-size: 14px;
+  }
+  .td-checkbox {
+    width: 20px;
+    height: 20px;
+    border-radius: 5px;
+  }
+  .td-actions {
+    gap: 12px;
+    margin-top: 16px;
+  }
+  .td-action {
+    padding: 8px 12px;
+    border-radius: 10px;
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 768px) {
+  :root {
+    --footer-h: 72px;
+  }
+  .footer {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: calc(var(--footer-h) + env(safe-area-inset-bottom, 0px));
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    z-index: 1000;
+    box-shadow: 0 -6px 20px rgba(0, 0, 0, 0.18);
+  }
+  .footer-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    height: var(--footer-h);
+    padding: 0 8px;
+  }
+  .footer-nav-item {
+    flex: 1 1 0;
+    max-width: 120px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 8px 10px;
+    border-radius: 14px;
+    line-height: 1.1;
+    text-decoration: none;
+  }
+  .footer-nav-item img {
+    width: 24px;
+    height: 24px;
+    display: block;
+  }
+  .footer-nav-item span {
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+  }
+  .footer-nav-item.active {
+    border-radius: 18px;
+    max-width: 96px;
+  }
+  body {
+    padding-bottom: calc(var(--footer-h) + env(safe-area-inset-bottom, 0px) + 16px);
+  }
+  .headercontainer {
+    padding-bottom: calc(var(--footer-h) + env(safe-area-inset-bottom, 0px) + 16px);
+  }
+  .main-content {
+    padding-bottom: calc(var(--footer-h) + env(safe-area-inset-bottom, 0px) + 16px);
+  }
+  .kb {
+    padding-bottom: calc(var(--footer-h) + env(safe-area-inset-bottom, 0px) + 16px);
+  }
+}

--- a/css/summary.css
+++ b/css/summary.css
@@ -24,7 +24,8 @@ body {
 }
 
 .icon__container--img {
-  width: 75%;
+  width: 32px;
+  height: 32px;
   object-fit: contain;
 }
 


### PR DESCRIPTION
What was changed

Styles split into two files:

- kb-desktop.css — rules for min-width: 1024px (+ specific tweaks for ≥1400px).
- kb-mobile.css — rules for ≤1024px, including breakpoints 768/480/360/320, modal styles (≤768px, ≤600px), and the mobile footer fix (≤768px).
- Formatting: all styles use one-property-per-line.
- Removed duplicate properties and repeated selectors.
- Minor visual tweaks without changing behavior (grouping and rule order).